### PR TITLE
Shorten VirionProcessor's regex check

### DIFF
--- a/src/Virion/VirionProcessor.php
+++ b/src/Virion/VirionProcessor.php
@@ -25,7 +25,7 @@ final class VirionProcessor implements Processor {
      * @param ?list<string> $sourceRoots
      */
     public function __construct(string $antigen, private string $epitope, private ?string $shared, private ?array $sourceRoots) {
-        if (!preg_match('#^[a-zA-Z0-9_]+(\\\\[a-zA-Z0-9_]+)+$#', $antigen, $matches)) {
+        if (!preg_match('#^\w+(?:\\\\\w+)+$#', $antigen, $matches)) {
             echo "\"$antigen\" is not a valid class name";
             exit(1);
         }


### PR DESCRIPTION
Old original: https://rubular.com/r/rbFHtoKeXfTOIb `^[a-zA-Z0-9_]+(\\\\[a-zA-Z0-9_]+)+$`
Group-based: https://rubular.com/r/n97pophwFTVzlf `^(?:[\w]+(?:\\\\)?)+$`, this allows `tes_1t\\dir\\`
Currently using: https://rubular.com/r/u2chZTVA19hZKj `^\w+(?:\\\\\w+)+$`, this allows `tes_1t\\dir`

```php
if (!preg_match('#^\w+(?:\\\\\w+)+$#', $antigen, $matches)) {
          echo "\"$antigen\" is not a valid class name";
          exit(1);
      }
      if (str_ends_with($epitope, "\\")) { // would this not be executed in both original and current regex?
          throw new RuntimeException("epitope must not end with a backslash");
      }
      ...
}
```