### PR TITLE
feat: add src-namespace-prefix support

### DIFF
--- a/src/Args.php
+++ b/src/Args.php
@@ -149,6 +149,10 @@ final class Args {
             $pluginYml = yaml_parse_file($inputDir . "/plugin.yml");
             if (isset($pluginYml["main"])) {
                 $main = $pluginYml["main"];
+				if (isset($pluginYml["src-namespace-prefix"])) {
+					$prefix = $pluginYml["src-namespace-prefix"];
+					Prefix::setPrefix("\\" . $prefix);
+				}
                 $lastNsSep = strrpos($main, "\\");
                 if ($lastNsSep !== false) {
                     $epitope = substr($main, 0, $lastNsSep + 1) . $epitope;

--- a/src/Main.php
+++ b/src/Main.php
@@ -59,7 +59,7 @@ final class Main {
         }
 
         foreach ($files as $file) {
-            $nsDir = $outputDir . "/" . $args->outputSourceRoot . "/" . str_replace("\\", "/", $file->namespace);
+            $nsDir = $outputDir . "/" . $args->outputSourceRoot . Prefix::validatePrefix(str_replace("\\", "/", "\\" . $file->namespace));
             if (!file_exists($nsDir)) {
                 Files::mkdir($nsDir);
             }

--- a/src/Prefix.php
+++ b/src/Prefix.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SOFe\Pharynx;
+
+final class Prefix{
+
+    private function __construct(){}
+
+    public static $prefix = "";
+
+    public static function validatePrefix(string $path) : string{
+        return str_replace(static::$prefix, "", $path);
+    }
+    
+    public static function setPrefix(string $prefix) : void{
+        static::$prefix = str_replace("\\", "/", $prefix);
+    }
+}


### PR DESCRIPTION
This PR is added src-namespace-prefix support to pharynx.

**Example Path**:

- Before
```string(99) "C:\Users\ACER\AppData\Local\Temp/bf004f8b/src/nicholass003/broadcaster/command/BroadcastCommand.php"```

- After
```string(74) "C:\Users\ACER\AppData\Local\Temp/97e46771/src/command/BroadcastCommand.php"```