### PR TITLE
feat: add validation to check for 'src-namespace-prefix' in plugin.yml

### DIFF
--- a/src/Args.php
+++ b/src/Args.php
@@ -149,6 +149,9 @@ final class Args {
             $pluginYml = yaml_parse_file($inputDir . "/plugin.yml");
             if (isset($pluginYml["main"])) {
                 $main = $pluginYml["main"];
+                if (isset($pluginYml["src-namespace-prefix"])) {
+                    throw Terminal::fatal("Error: Usage of 'src-namespace-prefix' in plugin.yml is not allowed.");
+                }
                 $lastNsSep = strrpos($main, "\\");
                 if ($lastNsSep !== false) {
                     $epitope = substr($main, 0, $lastNsSep + 1) . $epitope;


### PR DESCRIPTION
Add validation to check for 'src-namespace-prefix' in plugin.yml

- Added a validation check to ensure that 'src-namespace-prefix' key is not present in plugin.yml.
- Throw an error if 'src-namespace-prefix' is found to maintain plugin development.
